### PR TITLE
Add ax as argument to factorPlot, avoid warning

### DIFF
--- a/R/factorPlot.R
+++ b/R/factorPlot.R
@@ -1,4 +1,4 @@
-factorPlot <- function(v, partial, band, rug, w, line.par, fill.par, points.par, ...) {
+factorPlot <- function(v, partial, band, rug, w, line.par, fill.par, points.par, ax, ...) {
   ## Setup
   x <- v$res[,v$meta$x]
   y <- v$res$visregRes
@@ -39,9 +39,10 @@ factorPlot <- function(v, partial, band, rug, w, line.par, fill.par, points.par,
     }
   }
   new.args <- list(...)
-  if (!(("xaxt" %in% names(new.args)) && new.args$xaxt=="n")) {
+  if (!(("xaxt" %in% names(new.args)) && new.args$xaxt=="n" && !ax)) {
     axis.args <- list(side=1, at=(0:(K-1))/len+(1-w)/(2*len), labels=levels(x))
     if (length(new.args)) axis.args[names(new.args)] <- new.args
+    
     do.call("axis", axis.args)
   }
 }


### PR DESCRIPTION
After a recent update, `visreg` shows a warning for plots like,

```
visreg(model, "xfactor", by="yfactor", overlay=TRUE)
```

The warning was `"ax" is not a graphical parameter`. This is because `ax` is passed to `factorPlot` which does not expect it. I have added it as an argument and flag to turn off the plotting of the axes.